### PR TITLE
[IPS] Catch errors during batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ The `redact` package itself provides different ways to use the Redact API from P
 ### (Batch) File Processing
 
 The command-line shortcuts described above can be called programmatically through modules 
-`redact.redact_file` and `redact.redact_folder`. The latter allows for anonymizing
-several objects in parallel which usually results in a significant speed-up.
+`redact.redact_file` and `redact.redact_folder`. The latter has the optional argument `--n-parallel-jobs` for 
+anonymizing several objects in parallel which can result in a significant speed-up when processing many
+small files.
 
 ### API Requests
 

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "v3.7.1"
+__version__ = "v3.7.2"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa

--- a/redact/__main__.py
+++ b/redact/__main__.py
@@ -39,7 +39,7 @@ def redact_folder(in_dir: str, out_dir: str, input_type: InputType, out_type: Ou
                   region: Region = Region.european_union, face: bool = True, license_plate: bool = True,
                   licence_plate_custom_stamp_path: Optional[str] = typer.Option(None, '--custom-lp', help='Image file to use for license plate replacements'),
                   redact_url: str = settings.redact_url_default, subscription_key: Optional[str] = None,
-                  n_parallel_jobs: int = 5, save_labels: bool = False, skip_existing: bool = True,
+                  n_parallel_jobs: int = 1, save_labels: bool = False, skip_existing: bool = True,
                   auto_delete_job: bool = True):
     job_args = JobArguments(region=region, face=face, license_plate=license_plate)
     rdct_folder(in_dir=in_dir, out_dir=out_dir, input_type=input_type, out_type=out_type, service=service,

--- a/redact/redact_requests.py
+++ b/redact/redact_requests.py
@@ -64,7 +64,7 @@ class RedactRequests:
                                       files=files,
                                       headers=self._headers,
                                       params=job_args.dict(),
-                                      timeout=settings.requests_timeout_files)
+                                      timeout=settings.requests_timeout)
 
         if response.status_code != 200:
             raise RedactResponseError(response=response, msg='Error posting job')
@@ -74,7 +74,7 @@ class RedactRequests:
     def get_output(self, service: ServiceType, out_type: OutputType, output_id: UUID) -> JobResult:
 
         url = urllib.parse.urljoin(self.redact_url, f'{service}/{self.API_VERSION}/{out_type}/{output_id}')
-        response = self._session.get(url, headers=self._headers, timeout=settings.requests_timeout_files)
+        response = self._session.get(url, headers=self._headers, timeout=settings.requests_timeout)
 
         if response.status_code != 200:
             raise RedactResponseError(response=response, msg='Error downloading job result')

--- a/redact/settings.py
+++ b/redact/settings.py
@@ -6,4 +6,3 @@ class Settings(BaseSettings):
     redact_online_url: str = 'https://api.identity.ps/'
     redact_url_default: str = 'http://127.0.0.1:8787/'
     requests_timeout: int = 30
-    requests_timeout_files: int = 900  # for posting/downloading large files

--- a/tests/functional/test_subscription_key.py
+++ b/tests/functional/test_subscription_key.py
@@ -107,25 +107,24 @@ class TestRedactToolsWithSubscriptionKey:
                     service=ServiceType.blur,
                     save_labels=False)
 
-    def test_redact_folder_with_invalid_subscription_fails(self, images_path, tmp_path_factory):
+    def test_redact_folder_with_invalid_subscription_fails(self, images_path, tmp_path_factory, caplog):
 
         # GIVEN an input dir (with images) and an output dir
         output_path = tmp_path_factory.mktemp('imgs_dir_out')
 
         # WHEN the folder is anonymized through Redact Online with invalid subscription
-        with pytest.raises(RedactResponseError) as exception_info:
-            redact_folder(in_dir=str(images_path),
-                          out_dir=str(output_path),
-                          redact_url=REDACT_ONLINE_URL,
-                          input_type=InputType.images,
-                          out_type=OutputType.images,
-                          service=ServiceType.blur,
-                          n_parallel_jobs=1,
-                          subscription_key='INVALID_SUBSCRIPTION_KEY',
-                          save_labels=False)
+        redact_folder(in_dir=str(images_path),
+                      out_dir=str(output_path),
+                      redact_url=REDACT_ONLINE_URL,
+                      input_type=InputType.images,
+                      out_type=OutputType.images,
+                      service=ServiceType.blur,
+                      n_parallel_jobs=1,
+                      subscription_key='INVALID_SUBSCRIPTION_KEY',
+                      save_labels=False)
 
-        # THEN the response is 401
-        assert exception_info.value.response.status_code == 401
+        # THEN the logging contains error 401 (Not Authorized)
+        assert '[401]' in caplog.text
 
     def test_redact_folder_with_valid_subscription(self, images_path, subscription_key, tmp_path_factory):
 


### PR DESCRIPTION
- Errors used to stop batch processing of folders when `--n-parallel-jobs=1`. With this PR, errors are logged but the processing continues.
- The default for `n-parallel-jobs` is changed to `1` since that seems to be a better choice for the common use case of processing large videos.
- Setting `REQUESTS_TIMEOUT_FILES` is removed again (since it is not necessary)