### PR TITLE
Remove Requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pip-autoremove
           pip install flit
-      - name: Test Package Installation
+      - name: Build & Install Package
         run: |
           make install
       - name: Remove Aux. Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pip-autoremove
           pip install flit
-      - name: Test build
+      - name: Test Package Installation
         run: |
           make install
+      - name: Remove Aux. Dependencies
+        run: |
+          pip-autoremove flit -y
+      - name: Test CLI Endpoints
+        run: |
           make test-installation

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ install:
 	pip install . --upgrade
 
 test-installation:
-	redact_file --help > /dev/null && redact_folder --help > /dev/null && echo "OK: Command-line endpoints installed"
+	redact_file --help && redact_folder --help && echo "OK: Command-line endpoints installed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ requires = [
     "httpcore~=0.12.3",
     "httpx~=0.17.0",
     "pydantic~=1.6.1",
-    "requests~=2.24.0",
     "tqdm~=4.52.0",
     "typer~=0.3.2"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires = [
     "httpcore~=0.12.3",
     "httpx~=0.17.0",
     "pydantic~=1.6.1",
+    "requests~=2.24.0",
     "tqdm~=4.52.0",
     "typer~=0.3.2"
 ]

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "v3.8.2rc"
+__version__ = "v3.8.2"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "v3.8.1"
+__version__ = "v3.8.2"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "v3.8.1"
+__version__ = "v3.8.2rc"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "v3.8.2"
+__version__ = "v3.8.1"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "v3.8.0"
+__version__ = "v3.8.1"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa

--- a/redact/data_models.py
+++ b/redact/data_models.py
@@ -1,6 +1,6 @@
 from enum import Enum
+from httpx import Response
 from pydantic import BaseModel, Field, PositiveInt
-from requests import Response
 from typing import Optional, List, Tuple
 from uuid import UUID
 

--- a/redact/data_models.py
+++ b/redact/data_models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from requests import Response
+from httpx import Response
 from pydantic import BaseModel, Field, PositiveInt
 from typing import Optional, List, Tuple
 from uuid import UUID

--- a/redact/data_models.py
+++ b/redact/data_models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from httpx import Response
+from requests import Response
 from pydantic import BaseModel, Field, PositiveInt
 from typing import Optional, List, Tuple
 from uuid import UUID

--- a/tests/functional/test_subscription_key.py
+++ b/tests/functional/test_subscription_key.py
@@ -12,6 +12,7 @@ settings = Settings()
 REDACT_ONLINE_URL = settings.redact_online_url
 
 
+@pytest.mark.timeout(30)
 class TestRequestsWithSubscriptionKey:
 
     def test_post_with_invalid_key_fails(self, some_image):
@@ -36,6 +37,7 @@ class TestRequestsWithSubscriptionKey:
         redact.post_job(file=some_image, service=ServiceType.blur, out_type=OutputType.images)
 
 
+@pytest.mark.timeout(30)
 class TestJobWithSubscriptionKey:
 
     def test_job_with_invalid_subscription_fails(self, some_image):
@@ -76,6 +78,7 @@ class TestJobWithSubscriptionKey:
         job.delete()
 
 
+@pytest.mark.timeout(30)
 class TestRedactToolsWithSubscriptionKey:
 
     def test_redact_file_with_invalid_subscription_fails(self, images_path):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,5 @@ httpx==0.17.0
 pydantic==1.7.3
 pytest==6.2.2
 pytest-timeout==1.4.2
-requests==2.25.1
 tqdm==4.56.0
 typer==0.3.2


### PR DESCRIPTION
The `data_models` module was still dependent on `requests`. The tests didn't catch that dependency because `requests` was "accidentally" installed by `flit` (the packaging tool). Accordingly, this PR updates the tests to remove the `flit` dependencies when they aren't needed anymore.