### PR TITLE
[CT-193][1] Update Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.6"
 requires = [
     "httpcore~=0.12.3",
     "httpx~=0.17.1",
-    "pydantic~=1.8.1",
+    "pydantic~=1.8.2",
     "tqdm~=4.60.0",
     "typer~=0.3.2"
 ]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,8 +2,8 @@ fastapi==0.68.1
 flit==3.2.0
 httpcore==0.12.3
 httpx==0.17.1
-pydantic==1.8.1
-pytest==6.2.5
+pydantic==1.8.2
+pytest==6.2.3
 pytest-timeout==1.4.2
 tqdm==4.60.0
 typer==0.3.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
-fastapi==0.63.0
+fastapi==0.68.1
 flit==3.2.0
 httpcore==0.12.3
 httpx==0.17.1
 pydantic==1.8.1
-pytest==6.2.3
+pytest==6.2.5
 pytest-timeout==1.4.2
 tqdm==4.60.0
 typer==0.3.2


### PR DESCRIPTION
GitHub's Dependabot warned about known security issues in the used versions of `fastapi` and `pydantic`. This PR updates both dependencies to the most recent versions.