### PR TITLE
chore: Release 5.1.1, increase version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=5.1.0
+VERSION=5.1.1
 
 SHELL := /bin/bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redact"
-version = "5.1.0"
+version = "5.1.1"
 description = "Command-line and Python client for Brighter AI's Redact"
 authors = ["brighter AI <dev@brighter.ai>"]
 readme = "README.md"

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 from .redact_instance import RedactInstance  # noqa
 from .redact_job import RedactJob  # noqa


### PR DESCRIPTION
* Fix: Increase timeout for labels download CT-661. (#56)