### PR TITLE
[CT-691] feat: Add redact folder run summary

### DIFF
--- a/redact/main.py
+++ b/redact/main.py
@@ -10,8 +10,6 @@ from redact.tools.redact_folder import redact_folder as rdct_folder
 
 settings = Settings()
 
-log = logging.getLogger()
-
 
 def redact_file(
     file_path: str,

--- a/redact/tools/summary.py
+++ b/redact/tools/summary.py
@@ -1,0 +1,112 @@
+import functools
+import time
+from logging import Logger
+from typing import Any, Callable, List, Optional, Tuple
+
+from pydantic import BaseModel
+
+from redact.v3 import JobState, JobStatus
+
+
+class JobsSummary(BaseModel):
+    failed: int = 0
+    warnings: int = 0
+    successful: int = 0
+
+    def __eq__(self, other):
+        return (
+            self.failed == other.failed  # noqa: W503
+            and self.warnings == other.warnings  # noqa: W503
+            and self.successful == other.successful  # noqa: W503
+        )
+
+
+class TimeSummary(BaseModel):
+    time_overall: float
+    seconds: str
+    minutes: str
+    hours: str
+
+    def __eq__(self, other):
+        return (
+            self.time_overal == other.time_overall  # noqa: W503
+            and self.seconds == other.seconds  # noqa: W503
+            and self.minutes == other.minutes  # noqa: W503
+            and self.hours == other.hours  # noqa: W503
+        )
+
+
+JobStatuses = Tuple[List[Optional[JobStatus]], Any]
+RedactFolder = RedactFolderWrapper = Callable[..., JobStatuses]
+
+
+def summary(logger: Logger) -> Callable[[RedactFolder], RedactFolderWrapper]:
+    def decorator(redact_folder: RedactFolder) -> RedactFolderWrapper:
+        @functools.wraps(redact_folder)
+        def wrapper(*args: Any, **kwargs: Any) -> JobStatuses:
+            start_time = time.time()
+
+            job_statuses, exceptions = redact_folder(*args, **kwargs)
+
+            end_time = time.time()
+            time_difference = round(end_time - start_time, 1)
+
+            jobs_summary = calculate_jobs_summary(job_statuses, exceptions)
+            time_summary = calculate_time_summary(time_difference)
+
+            log_summary(logger, jobs_summary, time_summary)
+
+            return job_statuses, exceptions
+
+        return wrapper
+
+    return decorator
+
+
+def calculate_jobs_summary(
+    job_statuses: List[Optional[JobStatus]], exceptions: List[Any]
+) -> JobsSummary:
+    results = JobsSummary()
+
+    for job_status in job_statuses:
+        if job_status is not None:
+            if job_status.warnings:
+                results.warnings += 1
+
+            if job_status.state == JobState.failed:
+                results.failed += 1
+            elif job_status.state == JobState.finished:
+                results.successful += 1
+
+    results.failed += len(exceptions)
+
+    return results
+
+
+def calculate_time_summary(time_difference: float) -> TimeSummary:
+
+    return TimeSummary(
+        time_overall=time_difference,
+        seconds=_get_time_string(time_difference % 60),
+        minutes=_get_time_string(time_difference // 60),
+        hours=_get_time_string(time_difference // 3600),
+    )
+
+
+def _get_time_string(time_difference: float) -> str:
+    number_of_digits = 2
+
+    return str(int(time_difference)).zfill(number_of_digits)
+
+
+def log_summary(
+    logger: Logger, jobs_summary: JobsSummary, time_summary: TimeSummary
+) -> None:
+    logger.info(
+        f"Summary: "
+        f"{jobs_summary.failed} failed, "
+        f"{jobs_summary.successful} successful, "
+        f"{jobs_summary.warnings} warnings in "
+        f"{time_summary.time_overall}s "
+        f"({time_summary.hours}:{time_summary.minutes}:{time_summary.seconds}) "
+    )

--- a/redact/tools/summary.py
+++ b/redact/tools/summary.py
@@ -66,8 +66,8 @@ def log_summary(
     logger.info(
         f"Summary: "
         f"{jobs_summary.successful} successful, "
-        f"{jobs_summary.warnings} warnings in "
-        f"{jobs_summary.failed} failed, "
+        f"{jobs_summary.warnings} warnings, "
+        f"{jobs_summary.failed} failed in "
         f"{time_summary.time_overall}s "
         f"({time_summary.hours}:{time_summary.minutes}:{time_summary.seconds}) "
     )

--- a/redact/v3/utils.py
+++ b/redact/v3/utils.py
@@ -1,0 +1,24 @@
+from typing import Any, List, Optional
+
+from redact.tools.summary import JobsSummary
+from redact.v3 import JobState, JobStatus
+
+
+def calculate_jobs_summary(
+    job_statuses: List[Optional[JobStatus]], exceptions: List[Any]
+) -> JobsSummary:
+    jobs_summary = JobsSummary()
+
+    for job_status in job_statuses:
+        if job_status is not None:
+            if job_status.warnings:
+                jobs_summary.warnings += 1
+
+            if job_status.state == JobState.failed:
+                jobs_summary.failed += 1
+            elif job_status.state == JobState.finished:
+                jobs_summary.successful += 1
+
+    jobs_summary.failed += len(exceptions)
+
+    return jobs_summary

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ settings = Settings()
 
 logger = logging.getLogger()
 
+NUMBER_OF_IMAGES = 3
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -67,7 +69,7 @@ def some_custom_lp_stamp(resource_path: Path) -> IO:
 
 
 @pytest.fixture
-def images_path(tmp_path_factory, some_image, n_images: int = 3) -> Path:
+def images_path(tmp_path_factory, some_image, n_images: int = NUMBER_OF_IMAGES) -> Path:
     """
     Return a temporary directory that has been prepared with some image files:
     - img_0.jpg

--- a/tests/v3/functional/test_redact_folder.py
+++ b/tests/v3/functional/test_redact_folder.py
@@ -4,7 +4,7 @@ from typing import Union
 import pytest
 
 from redact.tools.redact_folder import redact_folder
-from redact.v3 import InputType, OutputType, ServiceType
+from redact.v3 import InputType, JobState, OutputType, ServiceType
 
 
 class TestRedactFolder:
@@ -24,7 +24,7 @@ class TestRedactFolder:
         output_path = tmp_path_factory.mktemp("imgs_dir_out")
 
         # WHEN the whole folder is anonymized
-        redact_folder(
+        results, _ = redact_folder(
             in_dir=images_path,
             out_dir=output_path,
             input_type=InputType.images,
@@ -53,6 +53,10 @@ class TestRedactFolder:
 
         # AND no other files have been created
         assert len(files_in_out_dir) == 2 * len(files_in_in_dir)
+
+        for job_status in results:
+            assert job_status
+            assert job_status.state == JobState.finished
 
     @staticmethod
     def _replace_file_ext(file_path: Union[str, Path], new_ext: str = ".json") -> str:

--- a/tests/v3/functional/test_redact_folder.py
+++ b/tests/v3/functional/test_redact_folder.py
@@ -4,7 +4,8 @@ from typing import Union
 import pytest
 
 from redact.tools.redact_folder import redact_folder
-from redact.v3 import InputType, JobState, OutputType, ServiceType
+from redact.v3 import InputType, OutputType, ServiceType
+from tests.conftest import NUMBER_OF_IMAGES
 
 
 class TestRedactFolder:
@@ -24,7 +25,7 @@ class TestRedactFolder:
         output_path = tmp_path_factory.mktemp("imgs_dir_out")
 
         # WHEN the whole folder is anonymized
-        results, _ = redact_folder(
+        jobs_summary = redact_folder(
             in_dir=images_path,
             out_dir=output_path,
             input_type=InputType.images,
@@ -54,9 +55,7 @@ class TestRedactFolder:
         # AND no other files have been created
         assert len(files_in_out_dir) == 2 * len(files_in_in_dir)
 
-        for job_status in results:
-            assert job_status
-            assert job_status.state == JobState.finished
+        assert jobs_summary.successful == NUMBER_OF_IMAGES
 
     @staticmethod
     def _replace_file_ext(file_path: Union[str, Path], new_ext: str = ".json") -> str:

--- a/tests/v3/functional/test_summary.py
+++ b/tests/v3/functional/test_summary.py
@@ -1,59 +1,9 @@
-from typing import Callable, List
 from unittest.mock import Mock
-from uuid import uuid4
 
-import pytest
-
-from redact.tools.summary import (
-    JobsSummary,
-    calculate_jobs_summary,
-    log_summary,
-    summary,
-)
-from redact.v3 import JobState, JobStatus
+from redact.tools.summary import JobsSummary, log_summary, summary
 
 
 class TestSummary:
-    @pytest.fixture
-    def get_job_status(self) -> Callable[[JobState], JobStatus]:
-        def _get_job_status(job_state: JobState) -> JobStatus:
-
-            return JobStatus(
-                output_id=uuid4(),
-                state=job_state,
-                warnings=["test_warning"],
-                error="test_error",
-            )
-
-        return _get_job_status
-
-    @pytest.fixture
-    def get_jobs_statuses(
-        self, get_job_status: Callable[[JobState], JobStatus]
-    ) -> Callable[[int, int], List[JobStatus]]:
-        def _get_jobs_statuses(
-            number_of_failed: int = 2, number_of_finished: int = 1
-        ) -> List[JobStatus]:
-            return [get_job_status(JobState.failed)] * number_of_failed + [
-                get_job_status(JobState.finished)
-            ] * number_of_finished
-
-        return _get_jobs_statuses
-
-    def test_calculate_jobs_summary(
-        self, get_jobs_statuses: Callable[[int, int], List[JobStatus]]
-    ):
-        exceptions = [None] * 3
-        number_of_failed = 2
-        number_of_finished = 1
-
-        job_summary = calculate_jobs_summary(
-            job_statuses=get_jobs_statuses(number_of_failed, number_of_finished),
-            exceptions=exceptions,
-        )
-
-        assert job_summary == JobsSummary(failed=5, warnings=3, successful=1)
-
     def test_log_summary(self):
         mock_logger = Mock()
         mock_logger.info = Mock()
@@ -62,21 +12,15 @@ class TestSummary:
 
         mock_logger.info.assert_called_once()
 
-    def test_summary(self, get_jobs_statuses: Callable[[int, int], List[JobStatus]]):
-        exceptions = [None] * 3
-        number_of_failed = 2
-        number_of_finished = 1
+    def test_summary(self):
+        expected_jobs_summary = JobsSummary(failed=5, warnings=3, successful=1)
 
-        jobs_statuses = get_jobs_statuses(number_of_failed, number_of_finished)
-
-        message = (
+        expected_part_of_message = (
             f"Summary: "
-            f"{number_of_failed + len(exceptions)} failed, "
-            f"{number_of_finished} successful, "
-            f"{number_of_failed+number_of_finished} warnings in "
+            f"{expected_jobs_summary.failed} failed, "
+            f"{expected_jobs_summary.successful} successful, "
+            f"{expected_jobs_summary.warnings} warnings in "
         )
-
-        mock_function = Mock(return_value=(jobs_statuses, exceptions))
 
         mock_logger = Mock()
         mock_logger.stdout = ""
@@ -86,8 +30,12 @@ class TestSummary:
 
         mock_logger.info = info
 
-        actual_jobs_statuses, actual_exceptions = summary(mock_logger)(mock_function)()
+        mock_function = Mock(return_value=expected_jobs_summary)
 
-        assert actual_jobs_statuses == jobs_statuses
-        assert actual_exceptions == exceptions
-        assert message in mock_logger.stdout
+        actual_jobs_summary = summary(mock_logger)(mock_function)()
+
+        mock_function.assert_called_once()
+        assert actual_jobs_summary.failed == expected_jobs_summary.failed
+        assert actual_jobs_summary.successful == expected_jobs_summary.successful
+        assert actual_jobs_summary.warnings == expected_jobs_summary.warnings
+        assert expected_part_of_message in mock_logger.stdout

--- a/tests/v3/functional/test_summary.py
+++ b/tests/v3/functional/test_summary.py
@@ -1,0 +1,93 @@
+from typing import Callable, List
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+
+from redact.tools.summary import (
+    JobsSummary,
+    calculate_jobs_summary,
+    log_summary,
+    summary,
+)
+from redact.v3 import JobState, JobStatus
+
+
+class TestSummary:
+    @pytest.fixture
+    def get_job_status(self) -> Callable[[JobState], JobStatus]:
+        def _get_job_status(job_state: JobState) -> JobStatus:
+
+            return JobStatus(
+                output_id=uuid4(),
+                state=job_state,
+                warnings=["test_warning"],
+                error="test_error",
+            )
+
+        return _get_job_status
+
+    @pytest.fixture
+    def get_jobs_statuses(
+        self, get_job_status: Callable[[JobState], JobStatus]
+    ) -> Callable[[int, int], List[JobStatus]]:
+        def _get_jobs_statuses(
+            number_of_failed: int = 2, number_of_finished: int = 1
+        ) -> List[JobStatus]:
+            return [get_job_status(JobState.failed)] * number_of_failed + [
+                get_job_status(JobState.finished)
+            ] * number_of_finished
+
+        return _get_jobs_statuses
+
+    def test_calculate_jobs_summary(
+        self, get_jobs_statuses: Callable[[int, int], List[JobStatus]]
+    ):
+        exceptions = [None] * 3
+        number_of_failed = 2
+        number_of_finished = 1
+
+        job_summary = calculate_jobs_summary(
+            job_statuses=get_jobs_statuses(number_of_failed, number_of_finished),
+            exceptions=exceptions,
+        )
+
+        assert job_summary == JobsSummary(failed=5, warnings=3, successful=1)
+
+    def test_log_summary(self):
+        mock_logger = Mock()
+        mock_logger.info = Mock()
+
+        log_summary(mock_logger, Mock(), Mock())
+
+        mock_logger.info.assert_called_once()
+
+    def test_summary(self, get_jobs_statuses: Callable[[int, int], List[JobStatus]]):
+        exceptions = [None] * 3
+        number_of_failed = 2
+        number_of_finished = 1
+
+        jobs_statuses = get_jobs_statuses(number_of_failed, number_of_finished)
+
+        message = (
+            f"Summary: "
+            f"{number_of_failed + len(exceptions)} failed, "
+            f"{number_of_finished} successful, "
+            f"{number_of_failed+number_of_finished} warnings in "
+        )
+
+        mock_function = Mock(return_value=(jobs_statuses, exceptions))
+
+        mock_logger = Mock()
+        mock_logger.stdout = ""
+
+        def info(message: str) -> None:
+            mock_logger.stdout = message
+
+        mock_logger.info = info
+
+        actual_jobs_statuses, actual_exceptions = summary(mock_logger)(mock_function)()
+
+        assert actual_jobs_statuses == jobs_statuses
+        assert actual_exceptions == exceptions
+        assert message in mock_logger.stdout

--- a/tests/v3/functional/test_summary.py
+++ b/tests/v3/functional/test_summary.py
@@ -17,9 +17,9 @@ class TestSummary:
 
         expected_part_of_message = (
             f"Summary: "
-            f"{expected_jobs_summary.failed} failed, "
             f"{expected_jobs_summary.successful} successful, "
-            f"{expected_jobs_summary.warnings} warnings in "
+            f"{expected_jobs_summary.warnings} warnings, "
+            f"{expected_jobs_summary.failed} failed in "
         )
 
         mock_logger = Mock()

--- a/tests/v3/functional/test_utils.py
+++ b/tests/v3/functional/test_utils.py
@@ -1,0 +1,55 @@
+from typing import Callable, List
+from uuid import uuid4
+
+import pytest
+
+from redact.tools.summary import JobsSummary
+from redact.v3 import JobState, JobStatus
+from redact.v3.utils import calculate_jobs_summary
+
+
+class TestSummary:
+    @pytest.fixture
+    def get_job_status(self) -> Callable[[JobState], JobStatus]:
+        def _get_job_status(job_state: JobState) -> JobStatus:
+            return JobStatus(
+                output_id=uuid4(),
+                state=job_state,
+                warnings=["test_warning"],
+                error="test_error",
+            )
+
+        return _get_job_status
+
+    @pytest.fixture
+    def get_jobs_statuses(
+        self, get_job_status: Callable[[JobState], JobStatus]
+    ) -> Callable[[int, int], List[JobStatus]]:
+        def _get_jobs_statuses(
+            number_of_failed: int = 2, number_of_finished: int = 1
+        ) -> List[JobStatus]:
+            return [get_job_status(JobState.failed)] * number_of_failed + [
+                get_job_status(JobState.finished)
+            ] * number_of_finished
+
+        return _get_jobs_statuses
+
+    def test_calculate_jobs_summary(
+        self, get_jobs_statuses: Callable[[int, int], List[JobStatus]]
+    ):
+        expected_jobs_summary = JobsSummary(failed=5, warnings=3, successful=1)
+
+        exceptions = [None] * 3
+
+        job_statuses = get_jobs_statuses(
+            expected_jobs_summary.failed - len(exceptions),
+            expected_jobs_summary.successful,
+        )
+
+        actual_job_summary = calculate_jobs_summary(
+            job_statuses=job_statuses, exceptions=exceptions
+        )
+
+        assert actual_job_summary.failed == expected_jobs_summary.failed
+        assert actual_job_summary.successful == expected_jobs_summary.successful
+        assert actual_job_summary.warnings == expected_jobs_summary.warnings


### PR DESCRIPTION
Summary of jobs was added to make `redact_folder` more informative.
Successful run look like this:
```bash
redact_folder $test_dir/images/ $test_dir/results/ images images blur --api-key=$api_key --n-parallel-jobs=10
2022-11-29 18:27:22,365 | INFO | Anonymize files from $test_dir/images ...
2022-11-29 18:27:22,366 | INFO | Found 2 images to process
2022-11-29 18:27:22,366 | INFO | Starting 10 parallel jobs to anonymize files ...
100%|███████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:10<00:00,  5.27s/it]
2022-11-29 18:27:32,914 | INFO | Summary: 2 successful, 0 warnings, 0 failed in 10.6s (00:00:10) 
```

Failed jobs with warnings look like this:
```bash
redact_folder $test_dir/images/ $test_dir/results/ images images blur --api-key=$api_key --n-parallel-jobs=10
2022-11-29 11:02:17,931 | INFO | Anonymize files from $test_dir/images ...
2022-11-29 11:02:17,932 | INFO | Found 2 images to process
2022-11-29 11:02:17,932 | INFO | Starting 10 parallel jobs to anonymize files ...
2022-11-29 11:02:28,270 | WARNING | Warning for '$test_dir/images/people_street_0.jpg': This is a test warning
2022-11-29 11:02:28,271 | ERROR | Job failed for '$test_dir/images/people_street_0.jpg': This is a test exception
2022-11-29 11:02:28,273 | WARNING | Warning for '$test_dir/images/people_street_1.jpg': This is a test warning
2022-11-29 11:02:28,274 | ERROR | Job failed for '$test_dir/images/people_street_1.jpg': This is a test exception
100%|███████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:10<00:00,  5.17s/it]
2022-11-29 11:02:28,275 | INFO | Summary: 0 successful, 2 warnings, 2 failed in 10.3s (00:00:10) 

```