### PR TITLE
[CT-2101] chore: Rename FBS threshold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=8.1.0
+VERSION=9.0.0
 
 SHELL := /bin/bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redact"
-version = "8.1.0"
+version = "9.0.0"
 description = "Command-line and Python client for Brighter AI's Redact"
 authors = ["brighter AI <dev@brighter.ai>"]
 readme = "README.md"

--- a/redact/__init__.py
+++ b/redact/__init__.py
@@ -2,7 +2,7 @@
 Python client for "brighter Redact"
 """
 
-__version__ = "8.1.0"
+__version__ = "9.0.0"
 
 from .errors import RedactConnectError, RedactResponseError
 from .v4.data_models import (

--- a/redact/tools/v4.py
+++ b/redact/tools/v4.py
@@ -84,7 +84,7 @@ def redact_file(
         ),
         show_default=False,
     ),
-    full_body_segmentation_threshold: Optional[float] = typer.Option(
+    full_body_determination_threshold: Optional[float] = typer.Option(
         None,
         help=(
             "Set the threshold between 0 and 1 that the full body segmentation model uses to decide if "
@@ -152,7 +152,7 @@ def redact_file(
         single_frame_optimized=single_frame_optimized,
         lp_determination_threshold=license_plate_determination_threshold,
         face_determination_threshold=face_determination_threshold,
-        full_body_segmentation_threshold=full_body_segmentation_threshold,
+        full_body_determination_threshold=full_body_determination_threshold,
         status_webhook_url=status_webhook_url,
         areas_of_interest=areas_of_interest,
     )
@@ -234,7 +234,7 @@ def redact_folder(
         ),
         show_default=False,
     ),
-    full_body_segmentation_threshold: Optional[float] = typer.Option(
+    full_body_determination_threshold: Optional[float] = typer.Option(
         None,
         help=(
             "Set the threshold between 0 and 1 that the full body segmentation model uses to decide if "
@@ -309,7 +309,7 @@ def redact_folder(
         single_frame_optimized=single_frame_optimized,
         lp_determination_threshold=license_plate_determination_threshold,
         face_determination_threshold=face_determination_threshold,
-        full_body_segmentation_threshold=full_body_segmentation_threshold,
+        full_body_determination_threshold=full_body_determination_threshold,
         status_webhook_url=status_webhook_url,
         areas_of_interest=areas_of_interest,
     )

--- a/redact/v4/data_models.py
+++ b/redact/v4/data_models.py
@@ -51,7 +51,7 @@ class JobArguments(BaseModel):
     single_frame_optimized: Optional[bool] = None
     lp_determination_threshold: Optional[float] = Field(None, ge=0, le=1)
     face_determination_threshold: Optional[float] = Field(None, ge=0, le=1)
-    full_body_segmentation_threshold: Optional[float] = Field(None, ge=0, le=1)
+    full_body_determination_threshold: Optional[float] = Field(None, ge=0, le=1)
     status_webhook_url: Optional[AnyHttpUrl] = None
     areas_of_interest: Optional[List[List[int]]] = None
 


### PR DESCRIPTION
To keep API parameters naming consistent,
we decided to rename
`*full_body_segmentation_threshold`
into
`*full_body_determination_threshold`